### PR TITLE
Required ruby version >= 2.1.0

### DIFF
--- a/onesignal.gemspec
+++ b/onesignal.gemspec
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'onesignal/version'
 
 Gem::Specification.new do |spec|
+  spec.required_ruby_version = '>= 2.1.0'
   spec.name          = 'onesignal'
   spec.version       = OneSignal::VERSION
   spec.authors       = ['Bastian Bartmann']


### PR DESCRIPTION
Once this gem use required keyword arguments it doesn't work with ruby < 2.1. 
